### PR TITLE
Fix logging error in ansari_db.get_thread()

### DIFF
--- a/ansari_db.py
+++ b/ansari_db.py
@@ -277,7 +277,7 @@ class AnsariDB:
                       'messages': [self.convert_message(x) for x in result if x[1] != 'function']}
             return retval
         except Exception as e:
-            logging.warning('Error is ', e)
+            logging.warning(f'Error is {e}')
             return {}
         finally:
             if cur: 


### PR DESCRIPTION
This pull request addresses a minor issue with logging in the `get_thread()` function of the `ansari_db.AnsariDB` class. 

The previous logging statement used an incorrect format, which led to `TypeError: not all arguments converted during string formatting`.

I've updated the logging statement to use an f-string for proper string formatting. 
With this tiny fix, the logging in the `get_thread()` function now works as expected.