### PR TITLE
Add script for Arabic diacritic stripping, and a README

### DIFF
--- a/data/mawsuah/README.md
+++ b/data/mawsuah/README.md
@@ -1,0 +1,47 @@
+# Arabic Diacritic Stripping for Word Documents
+
+## Overview
+
+This Python script prepares Arabic text in Microsoft Word documents from "The Kuwaiti Encyclopaedia of Islamic Jurisprudence" for use with Vectara Arabic text embedding models. It does this by removing diacritics (tashkeel) from the text.  This preprocessing step is essential for optimal semantic indexing and search functionality with Vectara. 
+
+## Why is this Important? 
+
+Without removing diacritics, Vectara's Arabic text embedding models cannot accurately represent the core meaning of words. This severely hinders the effectiveness of semantic search within the text.
+
+## Script Functionality
+
+The script leverages the following libraries to achieve its task:
+
+* **textract:** Extracts text content from Microsoft Word (.doc) files.
+* **pyarabic.araby:** Provides tools for stripping diacritics from Arabic text.
+
+## How to Use
+
+**1. Install Dependencies**
+
+Ensure you have the required libraries:
+
+```bash
+pip install PyArabic==0.6.15 textract==1.6.5 tqdm==4.66.1 
+```
+
+**2. Obtain the Source Documents**
+
+* Download "The Kuwaiti Encyclopaedia of Islamic Jurisprudence" Word documents from [this link](https://content.awqaf.gov.kw/BasicPages/2020/9/4fcf6da511ff40cfa278d5873f5ff3ad.rar).
+* Unrar the archive.
+* Place the extracted Word documents in a dedicated directory.
+
+**3. Configure the Script**
+
+* Open the Python script.
+* Update the `input_dir` variable with the full path to the directory containing the Word documents.
+
+**4. Run the Script**
+
+Execute the script from your terminal:
+
+```bash
+python strip_tashkeel.py
+```
+
+The script will process each Word document (.doc) in your specified directory and create a corresponding text file (.txt) with diacritics removed. The output files will be saved in a new folder called "txt" within the input directory.

--- a/data/mawsuah/strip_tashkeel.py
+++ b/data/mawsuah/strip_tashkeel.py
@@ -1,0 +1,26 @@
+from pathlib import Path, PurePath
+
+import textract
+from tqdm.auto import tqdm
+import pyarabic.araby as araby
+
+def strip_tashkeel_from_doc(input_file, output_file):
+    text = textract.process(input_file).decode('utf-8')  # Extract text from .doc file
+
+    stripped_text = araby.strip_diacritics(text)
+
+    with open(output_file, 'w', encoding='utf-8') as f:
+        f.write(stripped_text)
+
+
+input_dir = Path("/path/to/The Kuwaiti Encyclopaedia of Islamic Jurisprudence/word")
+path_components = list(input_dir.parts)
+path_components[-1] = "txt"
+output_dir = PurePath(*path_components) # --> "/path/to/The Kuwaiti Encyclopaedia of Islamic Jurisprudence/txt"
+
+# iterate over all files in the directory
+for input_file in tqdm(input_dir.glob('*.doc')):
+    if input_file.is_file() and input_file.suffix == '.doc':
+        print(f"Processing {input_file.name}...")
+        strip_tashkeel_from_doc(input_file, output_dir.joinpath(input_file.with_suffix('.txt').name))
+        print(f"Done processing {input_file.name}")


### PR DESCRIPTION
This PR introduces a script to preprocess Arabic text from 'The Kuwaiti Encyclopaedia of Islamic Jurisprudence', removing diacritics to optimize its use with Vectara models. This change aims to enhance semantic search capabilities.

Following Waleed's feedback, it also includes clear instructions in the README.md on how reproduce the data. This ensures maintainability and the ability to reconstruct the dataset if necessary.